### PR TITLE
RPM support scripts

### DIFF
--- a/tools/rpm/postinstall.sh
+++ b/tools/rpm/postinstall.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+#Using INSTALLING_SERVICE rather than SERVICE_NAME because
+# when this script runs, Jenkins is out of the picture and can't pass in vars
+INSTALLING_SERVICE=EDITME
+
+if [ $INSTALLING_SERVICE == EDITME ]; then
+  echo "Script was supposed to be edited by jenkins job first."
+  exit 1
+fi
+
+chmod a+rwx /var/log/msl
+JAR_TO_EXEC=`find /opt/kenzan/$INSTALLING_SERVICE-*-with-dependencies.jar`
+
+if [ `echo $JAR_TO_EXEC | wc -l` == 1 ]; then
+  echo "Adding startup line to rc.local" | tee -a /tmp/msl-install.log
+  echo "/usr/bin/java8 -jar $JAR_TO_EXEC 2>&1 | tee -a /var/log/msl/$INSTALLING_SERVICE.log" | tee -a /tmp/msl-install.log | tee /opt/kenzan/startup.sh
+  chmod +x /opt/kenzan/startup.sh > /dev/null
+  echo "/usr/bin/screen -dmS $INSTALLING_SERVICE /opt/kenzan/startup.sh" | tee -a /etc/rc.local
+else
+  echo "Wrong number of $INSTALLING_SERVICE jars found in /opt/kenzan/" | tee -a /tmp/msl-install.log
+  exit 1
+fi

--- a/tools/rpm/preinstall.sh
+++ b/tools/rpm/preinstall.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+#See if Java 8 is installed, if not, give it a shot
+#Useful if we're applying MSL to a bare Amazon Linux AMI instead of
+# an AMI we built
+
+date > /tmp/msl-install.log
+
+if [ -a /usr/bin/java8 ]; then
+  echo "Java8 already installed" | tee -a /tmp/msl-install.log
+else
+    yum install java-1.8.0-openjdk | tee -a /tmp/msl-install.log
+fi


### PR DESCRIPTION
These scripts are used by the maven RPM plugin for the edge services. (Edge services need a minor refactor so that plugin doesn't require any file moves during building.)